### PR TITLE
attr/xattr.h is deprecated. Use sys/xattr.h instead

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -156,7 +156,7 @@ fi
 
 if test x$enable_eua = xyes;
 then
-    AC_CHECK_HEADERS([attr/xattr.h], [], AC_MSG_ERROR([This header is mandatory for extended user attributes support]), [])
+    AC_CHECK_HEADERS([sys/xattr.h], [], AC_MSG_ERROR([This header is mandatory for extended user attributes support]), [])
     AC_DEFINE([ENABLE_USER_XATTR], [1], [Enables user extended attributes support])
 fi
 AM_CONDITIONAL(ENABLE_USER_XATTR, test x$enable_eua = xyes)

--- a/src/xattr_manager.hpp
+++ b/src/xattr_manager.hpp
@@ -26,7 +26,10 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include <attr/xattr.h>
+#include <sys/xattr.h>
+#ifndef ENOATTR
+#define ENOATTR ENODATA
+#endif
 
 #include <string>
 #include <cstring>


### PR DESCRIPTION
See also:
http://git.savannah.nongnu.org/cgit/attr.git/commit/?id=7921157890d07858d092f4003ca4c6bae9fd2c38