### PR TITLE
avoid C++ name mangling for Nautilus extension symbols

### DIFF
--- a/src/eiciel_nautilus_page.cpp
+++ b/src/eiciel_nautilus_page.cpp
@@ -22,8 +22,9 @@
 #include <glib/gi18n-lib.h>
 #include <gtk/gtk.h>
 #include <gtkmm.h>
-#include <libnautilus-extension/nautilus-property-page-provider.h>
-#include <libnautilus-extension/nautilus-property-page.h>
+extern "C" {
+#include <nautilus-extension.h>
+}
 
 #include "eiciel_main_window.hpp"
 #include "eiciel_main_window_controller.hpp"


### PR DESCRIPTION
On Fedora 31 (perhaps earlier), the extension started to fail like this:

detected unhandled Python exception in 'nautilus'
'nautilus_module_initialize': /usr/lib64/nautilus/extensions-3.0/libeiciel-nautilus.so: undefined symbol: nautilus_module_initialize
