### PR TITLE
Add missing files to dist tarball

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,6 +13,7 @@ common_sources = \
 				 eiciel_participant_list.hpp \
 				 eiciel_participant_list_controller.cpp \
 				 eiciel_participant_list_controller.hpp \
+				 eiciel_participant_target.hpp \
 				 eiciel_enclosed_editor_window_controller.hpp \
 				 eiciel_enclosed_editor_window_controller.cpp \
 				 eiciel_enclosed_editor_window.hpp \


### PR DESCRIPTION
Without it, the build fails:
```
In file included from eiciel_main_window.hpp:25,
                 from eiciel_main_window.cpp:19:
eiciel_main_window_controller.hpp:26:10: fatal error: eiciel_participant_target.hpp: No such file or directory
   26 | #include "eiciel_participant_target.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[3]: *** [Makefile:857: eiciel-eiciel_main_window.o] Error 1
make[3]: *** Waiting for unfinished jobs....
In file included from eiciel_enclosed_editor_window.hpp:27,
                 from eiciel_main_window_controller.cpp:22:
eiciel_participant_list.hpp:24:10: fatal error: eiciel_participant_target.hpp: No such file or directory
   24 | #include "eiciel_participant_target.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[3]: *** [Makefile:871: eiciel-eiciel_main_window_controller.o] Error 1
make[3]: Leaving directory '/home/michael/debian/build-area/eiciel-0.9.13/src'
make[2]: *** [Makefile:440: all-recursive] Error 1
make[2]: Leaving directory '/home/michael/debian/build-area/eiciel-0.9.13'
make[1]: *** [Makefile:372: all] Error 2
make[1]: Leaving directory '/home/michael/debian/build-area/eiciel-0.9.13'
```
It would probably make sense to include `make distcheck` as part of the release process.