### PR TITLE
Fix encoding of AUTHORS file to be UTF-8

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,5 @@
 Eiciel - A graphical editor for POSIX ACL under GNOME 2
 
-Author: Roger Ferrer Ib·Òez <rofi@ya.com>
+Author: Roger Ferrer Ib√°√±ez <rofi@ya.com>
 
 Released under GPL license


### PR DESCRIPTION
Fixes the following error detected by lintian:

W: eiciel: national-encoding usr/share/doc/eiciel/AUTHORS
N:
W: national-encoding
N:
N:   A file is not valid UTF-8.
N:
N:   Debian has used UTF-8 for many years. Support for national encodings
N:   is being phased out. This file probably appears to users in mangled
N:   characters (also called mojibake).
N:
N:   Packaging control files must be encoded in valid UTF-8.
N:
N:   Please convert the file to UTF-8 using iconv or a similar tool.
N:
N:   Severity: warning
N:
N:   Check: files/encoding
N:
N:   Renamed from: national-encoding-in-text-file
N:   debian-changelog-file-uses-obsolete-national-encoding
N:   debian-control-file-uses-obsolete-national-encoding
N:   debian-copyright-file-uses-obsolete-national-encoding
N:   debian-news-file-uses-obsolete-national-encoding
N:   debian-tests-control-uses-national-encoding
N:   doc-base-file-uses-obsolete-national-encoding
N:   national-encoding-in-debconf-template national-encoding-in-manpage
N: