### PR TITLE
build: Fix finding libacl

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -49,7 +49,7 @@ conf_data.set('ENABLE_USER_XATTR',
               user_attributes_feature.enabled())
 
 # Libraries
-libacl = compiler.find_library('libacl')
+libacl = compiler.find_library('acl')
 
 has_acl_get_perm = compiler.has_function('acl_get_perm', dependencies: libacl)
 conf_data.set('HAVE_ACL_GET_PERM', has_acl_get_perm)


### PR DESCRIPTION
Otherwise it fails on Nix:

```
ERROR: C++ shared or static library 'libacl' not found
```

Opened docs PR: https://github.com/mesonbuild/meson/pull/10838