### PR TITLE
Optional GNOME Files support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -27,9 +27,12 @@ conf_data.set_quoted('LOCALEDIR', localedir)
 # Dependencies
 gtkmm4 = dependency('gtkmm-4.0', version: '>= 4.6')
 giomm = dependency('giomm-2.68', version: '>= 2.68')
+thread_dep = dependency('threads')
+nautilus_plugin_feature = get_option('nautilus-plugin')
+if nautilus_plugin_feature.enabled()
 libnautilus_extensions4 = dependency('libnautilus-extension-4',
                                       version: '>= 43')
-thread_dep = dependency('threads')
+endif
 
 # Compiler
 compiler = meson.get_compiler('cpp')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,6 +2,10 @@ option('user-attributes',
     type : 'feature',
     value : 'enabled',
     description : 'Enables support for editing extended user attributes')
+option('nautilus-plugin',
+    type : 'feature',
+    value : 'enabled',
+    description: 'Enable nautilus extension plugin')
 option('nautilus-extension-dir',
     type: 'string',
     value : '',

--- a/src/meson.build
+++ b/src/meson.build
@@ -56,6 +56,8 @@ executable('eiciel',
 
 
 # Plugin for nautilus
+nautilusextensiondir = get_option('nautilus-extension-dir')
+if nautilus_plugin_feature.enabled()
 plugin_sources = utility_libraries
 plugin_sources += ['nautilus_menu_provider.cpp',
                    'nautilus_acl_model.cpp',
@@ -64,7 +66,6 @@ plugin_sources += ['nautilus_menu_provider.cpp',
                    'nautilus_extension.cpp',
                    'i18n.cpp']
 
-nautilusextensiondir = get_option('nautilus-extension-dir')
 if nautilusextensiondir == '' 
   nautilusextensiondir = libnautilus_extensions4.get_variable(pkgconfig : 'extensiondir')
 endif
@@ -75,6 +76,7 @@ shared_module('eiciel-nautilus',
   install_dir : nautilusextensiondir,
   include_directories : incdir,
   dependencies : [gtkmm4, giomm, libnautilus_extensions4, libacl, thread_dep])
+endif
 
 # Desktop file
 desktop_file_data = configuration_data()


### PR DESCRIPTION
If the GNOME Files support not required, it can be disabled.